### PR TITLE
Add production data implementation

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -15,16 +15,11 @@ permissions:
 jobs:
   build:
     runs-on: ubuntu-latest
-
     steps:
     - uses: actions/checkout@v4
-    - name: setup rye
-      uses: sksat/setup-rye@v0.28.0
-      with:
-        use-uv: true
-    - name: sync
-      run: rye sync
-    - name: lint
-      run: rye lint
-    - name: test
-      run: rye test
+    - run: curl -LsSf https://astral.sh/uv/install.sh | sh
+    - run: source $HOME/.cargo/env
+    - run: uv venv
+    - run: uv pip install ruff pytest httpx
+    - run: uv run ruff check
+    - run: uv run pytest

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -22,4 +22,4 @@ jobs:
     - run: uv venv
     - run: uv pip install ruff pytest httpx
     - run: uv run ruff check
-    - run: uv run pytest
+    - run: uv run pytest -v

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -19,7 +19,7 @@ jobs:
     steps:
     - uses: actions/checkout@v4
     - name: setup rye
-      uses: sksat/setup-rye@v0.27.0
+      uses: sksat/setup-rye@v0.28.0
       with:
         use-uv: true
     - name: sync

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -38,6 +38,7 @@ managed = true
 dev-dependencies = [
     "pytest>=8.3.1",
     "ruff>=0.6.2",
+    "httpx>=0.27.0",
 ]
 
 [tool.hatch.metadata]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -39,6 +39,7 @@ build-backend = "hatchling.build"
 managed = true
 dev-dependencies = [
     "pytest>=8.3.1",
+    "ruff>=0.6.2",
 ]
 
 [tool.hatch.metadata]
@@ -46,3 +47,6 @@ allow-direct-references = true
 
 [tool.hatch.build.targets.wheel]
 packages = ["src/webgwas_backend"]
+
+[tool.ruff.lint.pydocstyle]
+convention = "google"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "webgwas-backend"
-version = "0.1.3"
+version = "0.2.0"
 description = "Add your description here"
 authors = [
     { name = "zietzm", email = "michael.zietz@gmail.com" }

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,11 +7,9 @@ authors = [
 ]
 dependencies = [
     "fastapi>=0.111.0",
-    "psutil>=6.0.0",
     "boto3>=1.34.145",
     "botocore>=1.34.145",
     "pydantic>=2.8.2",
-    "cachetools>=5.4.0",
     "pandas>=2.2.2",
     "pydantic-settings>=2.3.4",
     "zstandard>=0.23.0",

--- a/requirements-dev.lock
+++ b/requirements-dev.lock
@@ -151,7 +151,7 @@ uvloop==0.19.0
     # via uvicorn
 watchfiles==0.22.0
     # via uvicorn
-webgwas @ git+https://github.com/zietzm/webgwas.git@f5514d2d3d6955779a42ee6a03d81c06684b3a2c
+webgwas @ git+https://github.com/zietzm/webgwas.git@bb627b570e507222accd2fdf08a896565835db0d
     # via webgwas-backend
 websockets==12.0
     # via uvicorn

--- a/requirements-dev.lock
+++ b/requirements-dev.lock
@@ -22,8 +22,6 @@ botocore==1.34.145
     # via boto3
     # via s3transfer
     # via webgwas-backend
-cachetools==5.4.0
-    # via webgwas-backend
 certifi==2024.7.4
     # via httpcore
     # via httpx
@@ -82,8 +80,6 @@ pandas==2.2.2
 pluggy==1.5.0
     # via pytest
 polars==1.3.0
-    # via webgwas-backend
-psutil==6.0.0
     # via webgwas-backend
 pyarrow==17.0.0
     # via webgwas-backend

--- a/requirements-dev.lock
+++ b/requirements-dev.lock
@@ -115,6 +115,7 @@ pyyaml==6.0.1
 rich==13.7.1
     # via typer
     # via webgwas-backend
+ruff==0.6.2
 s3transfer==0.10.2
     # via boto3
 shellingham==1.5.4

--- a/requirements.lock
+++ b/requirements.lock
@@ -22,8 +22,6 @@ botocore==1.34.145
     # via boto3
     # via s3transfer
     # via webgwas-backend
-cachetools==5.4.0
-    # via webgwas-backend
 certifi==2024.7.4
     # via httpcore
     # via httpx
@@ -76,8 +74,6 @@ pandas==2.2.2
     # via webgwas
     # via webgwas-backend
 polars==1.3.0
-    # via webgwas-backend
-psutil==6.0.0
     # via webgwas-backend
 pyarrow==17.0.0
     # via webgwas-backend

--- a/requirements.lock
+++ b/requirements.lock
@@ -144,7 +144,7 @@ uvloop==0.19.0
     # via uvicorn
 watchfiles==0.22.0
     # via uvicorn
-webgwas @ git+https://github.com/zietzm/webgwas.git@f5514d2d3d6955779a42ee6a03d81c06684b3a2c
+webgwas @ git+https://github.com/zietzm/webgwas.git@bb627b570e507222accd2fdf08a896565835db0d
     # via webgwas-backend
 websockets==12.0
     # via uvicorn

--- a/settings.toml
+++ b/settings.toml
@@ -3,8 +3,4 @@ s3_bucket = "webgwas-ohio"
 sqlite_db = "sqlite:///backend.db"
 
 [indirect_gwas]
-num_threads = 1
-chunk_size = 10000
-capacity = 5
-compress = true
-quiet = false
+batch_size = 10000

--- a/settings.toml
+++ b/settings.toml
@@ -1,6 +1,7 @@
 dry_run = true
 s3_bucket = "webgwas-ohio"
 sqlite_db = "sqlite:///backend.db"
+n_workers = 1
 
 [indirect_gwas]
 batch_size = 10000

--- a/src/webgwas_backend/cli/register_cohort.py
+++ b/src/webgwas_backend/cli/register_cohort.py
@@ -156,7 +156,7 @@ class CohortFiles:
             logger.debug(f"Anonymized phenotypes: {anon_df}")
             if mean_center:
                 anon_df = anon_df - anon_df.mean(axis=0)
-            logger.debug(f"Anonymized phenotypes: {anon_df}")
+            logger.debug(f"Anonymized, mean-centered phenotypes: {anon_df}")
             anon_df.to_parquet(self.phenotype_path)
             Y = anon_df
         else:
@@ -166,7 +166,6 @@ class CohortFiles:
             logger.debug(f"Phenotypes: {Y}")
             Y.to_parquet(self.phenotype_path)
         logger.info("Computing left inverse")
-        logger.debug(f"Phenotypes: {Y}")
         left_inverse = webgwas.regression.compute_left_inverse(Y)
         logger.debug(f"Left inverse: {left_inverse}")
         del Y  # Free up memory

--- a/src/webgwas_backend/cli/register_cohort.py
+++ b/src/webgwas_backend/cli/register_cohort.py
@@ -193,9 +193,9 @@ class CohortFiles:
         logger.info("Reading GWAS files")
         schema_overrides = {
             variant_id: pl.Utf8,
-            beta: pl.Float64,
-            std_error: pl.Float64,
-            sample_size: pl.Int64,
+            beta: pl.Float32,
+            std_error: pl.Float32,
+            sample_size: pl.Int32,
         }
         assert self.features is not None
         full_gwas_df = None

--- a/src/webgwas_backend/config.py
+++ b/src/webgwas_backend/config.py
@@ -3,18 +3,13 @@ from __future__ import annotations
 import json
 from typing import Any
 
-import psutil
 from dynaconf import Dynaconf
 from pydantic import BaseModel, Field
 from pydantic_settings import BaseSettings
 
 
 class IndirectGWASSettings(BaseModel):
-    num_threads: int = Field(psutil.cpu_count(), description="Number of threads")
-    chunk_size: int = Field(1000000, description="Chunk size (in variants)")
-    capacity: int = Field(25, description="Capacity (in phenotypes)")
-    compress: bool = Field(True, description="Compress output (zstd)")
-    quiet: bool = Field(False, description="Quiet mode")
+    batch_size: int = Field(10000, description="Batch size (in variants)")
 
 
 class Settings(BaseSettings):

--- a/src/webgwas_backend/config.py
+++ b/src/webgwas_backend/config.py
@@ -17,6 +17,7 @@ class Settings(BaseSettings):
     s3_bucket: str
     sqlite_db: str
     indirect_gwas: IndirectGWASSettings
+    n_workers: int
 
     @classmethod
     def from_json(cls, json_data: dict[str, Any]) -> Settings:

--- a/src/webgwas_backend/database.py
+++ b/src/webgwas_backend/database.py
@@ -1,5 +1,6 @@
 import pathlib
 
+from sqlalchemy import Engine
 from sqlmodel import create_engine
 
 from webgwas_backend.config import settings
@@ -8,9 +9,9 @@ from webgwas_backend.models import SQLModel
 engine = create_engine(settings.sqlite_db)
 
 
-def db_exists() -> bool:
-    return pathlib.Path(settings.sqlite_db.lstrip("sqlite:").lstrip("/")).exists()
+def db_exists(path: str = settings.sqlite_db) -> bool:
+    return pathlib.Path(path.lstrip("sqlite:").lstrip("/")).exists()
 
 
-def init_db():
+def init_db(engine: Engine = engine) -> None:
     SQLModel.metadata.create_all(engine)

--- a/src/webgwas_backend/igwas_handler.py
+++ b/src/webgwas_backend/igwas_handler.py
@@ -55,6 +55,7 @@ def handle_igwas(request: WebGWASRequestID, s3_client: S3Client) -> WebGWASResul
     )
     covariance_matrix = pd.read_csv(cov_path, index_col=0)
     gwas_path = pathlib.Path(request.cohort.root_directory).joinpath("gwas.parquet")
+    assert gwas_path.exists(), f"GWAS file not found: {gwas_path}"
 
     with tempfile.TemporaryDirectory() as temp_dir:
         logger.info("Running Indirect GWAS")

--- a/src/webgwas_backend/main.py
+++ b/src/webgwas_backend/main.py
@@ -99,7 +99,12 @@ def validate_phenotype(
         webgwas.phenotype_definitions.type_check_nodes(nodes)
     except Exception as e:
         raise HTTPException(status_code=400, detail=f"Error validating phenotype: {e}")
-    return ValidPhenotype(phenotype_definition=phenotype_definition, valid_nodes=nodes)
+    return ValidPhenotype(
+        phenotype_definition=phenotype_definition,
+        valid_nodes=nodes,
+        is_valid=True,
+        message="Valid phenotype",
+    )
 
 
 @app.post("/api/igwas", response_model=WebGWASResponse)

--- a/src/webgwas_backend/main.py
+++ b/src/webgwas_backend/main.py
@@ -57,17 +57,29 @@ def validate_cohort(
     return cohort
 
 
-@app.get("/api/cohorts", response_model=list[CohortResponse])
+@app.get(
+    "/api/cohorts",
+    response_model=list[CohortResponse],
+    response_model_exclude_none=True,
+)
 def get_cohorts(session: Annotated[Session, Depends(get_session)]):
     return session.exec(select(Cohort)).all()
 
 
-@app.get("/api/features", response_model=list[FeatureResponse])
+@app.get(
+    "/api/features",
+    response_model=list[FeatureResponse],
+    response_model_exclude_none=True,
+)
 def get_nodes(cohort: Annotated[Cohort, Depends(validate_cohort)]):
     return cohort.features
 
 
-@app.put("/api/phenotype", response_model=ValidPhenotypeResponse)
+@app.put(
+    "/api/phenotype",
+    response_model=ValidPhenotypeResponse,
+    response_model_exclude_none=True,
+)
 def validate_phenotype(
     *,
     cohort: Annotated[Cohort, Depends(validate_cohort)],
@@ -101,7 +113,9 @@ def validate_phenotype(
     )
 
 
-@app.post("/api/igwas", response_model=WebGWASResponse)
+@app.post(
+    "/api/igwas", response_model=WebGWASResponse, response_model_exclude_none=True
+)
 def post_igwas(
     cohort: Annotated[Cohort, Depends(validate_cohort)],
     phenotype_definition: Annotated[ValidPhenotype, Depends(validate_phenotype)],
@@ -115,7 +129,11 @@ def post_igwas(
     return WebGWASResponse(request_id=new_request.id, status="queued")
 
 
-@app.get("/api/igwas/results/{request_id}", response_model=WebGWASResult)
+@app.get(
+    "/api/igwas/results/{request_id}",
+    response_model=WebGWASResult,
+    response_model_exclude_none=True,
+)
 def get_igwas_results(
     request_id: str, worker: Annotated[Worker, Depends(get_worker)]
 ) -> WebGWASResult:

--- a/src/webgwas_backend/models.py
+++ b/src/webgwas_backend/models.py
@@ -86,11 +86,9 @@ class WebGWASResponse(SQLModel):
     )
 
 
-class WebGWASResult(SQLModel):
+class WebGWASResult(WebGWASResponse):
     """Result of a successful GWAS"""
 
-    request_id: str = Field(..., description="Unique identifier for the request.")
-    status: str = Field(..., description="Status of the request.")
     error_msg: str | None = Field(
         default=None, description="Error message if status is 'error'."
     )

--- a/src/webgwas_backend/models.py
+++ b/src/webgwas_backend/models.py
@@ -41,6 +41,8 @@ class Feature(FeatureResponse, SQLModel, table=True):
 
 
 class ValidPhenotypeResponse(SQLModel):
+    is_valid: bool
+    message: str
     phenotype_definition: str
 
 

--- a/src/webgwas_backend/test_main.py
+++ b/src/webgwas_backend/test_main.py
@@ -146,6 +146,7 @@ def client():
     app.dependency_overrides[get_worker] = get_worker_override
     with TestClient(app) as client:
         yield client
+    worker.shutdown()
 
 
 def test_get_cohorts(client):
@@ -191,7 +192,7 @@ def test_post_igwas(client: TestClient, phenotype_definition: str):
     validated = WebGWASResponse.model_validate(response.json())
     assert validated.status == "queued"
     time.sleep(0.1)
-    for _ in range(10):
+    for _ in range(20):
         status_response = client.get(f"/api/igwas/results/{validated.request_id}")
         assert status_response.status_code in {200, 202}, status_response.json()
         validated_status = WebGWASResult.model_validate(status_response.json())

--- a/src/webgwas_backend/test_main.py
+++ b/src/webgwas_backend/test_main.py
@@ -19,7 +19,7 @@ from webgwas_backend.models import (
     WebGWASResponse,
     WebGWASResult,
 )
-from webgwas_backend.worker import Worker
+from webgwas_backend.worker import TestWorker
 
 
 def setup_db(session: Session, rootdir: pathlib.Path):
@@ -134,10 +134,10 @@ def client():
         dry_run=True,
         s3_bucket="TEST",
         sqlite_db=":memory:",
-        n_workers=1,
+        n_workers=2,
         indirect_gwas=IndirectGWASSettings(batch_size=10000),
     )
-    worker = Worker(settings)
+    worker = TestWorker(settings)
 
     def get_worker_override():
         return worker
@@ -146,7 +146,6 @@ def client():
     app.dependency_overrides[get_worker] = get_worker_override
     with TestClient(app) as client:
         yield client
-    worker.shutdown()
 
 
 def test_get_cohorts(client):

--- a/src/webgwas_backend/test_main.py
+++ b/src/webgwas_backend/test_main.py
@@ -196,9 +196,13 @@ def test_post_igwas(client: TestClient, phenotype_definition: str):
         assert status_response.status_code in {200, 202}, status_response.json()
         validated_status = WebGWASResult.model_validate(status_response.json())
         assert validated_status.request_id == validated.request_id
-        if validated_status.status == "done":
-            break
-        time.sleep(0.1)
+        match validated_status.status:
+            case "done":
+                break
+            case "queued":
+                time.sleep(0.1)
+            case "error":
+                raise ValueError(f"Unexpected status: {validated_status}")
     else:
         raise TimeoutError("Timed out waiting for IGWAS to complete")
 

--- a/src/webgwas_backend/worker.py
+++ b/src/webgwas_backend/worker.py
@@ -55,3 +55,7 @@ class Worker:
             if future.done():
                 return future.result()
         raise HTTPException(status_code=500, detail=f"Internal error: {future}")
+
+    def shutdown(self):
+        self.executor.shutdown(wait=True, cancel_futures=True)
+        self.manager.shutdown()

--- a/src/webgwas_backend/worker.py
+++ b/src/webgwas_backend/worker.py
@@ -30,7 +30,7 @@ class Worker:
             request = self.job_queue.get()
             logger.info(f"Got request: {request}")
             try:
-                result = handle_igwas(request, self.s3_client, self.settings)
+                result = handle_igwas(request, self.s3_client)
                 self.results[request.id] = result
                 logger.info(f"Finished request: {request.id}")
             except Exception as e:


### PR DESCRIPTION
This provides a roughly 80% reduction in runtime for indirect GWAS, and it avoids hanging during these long-running (~1 minute) computations.

* Parquet files for all GWAS results
* Improved data registration through the CLI
* Enables more worker processes
* Thread safe implementation